### PR TITLE
updated podspecs swift language version to 4.2

### DIFF
--- a/MessageInputBar.podspec
+++ b/MessageInputBar.podspec
@@ -12,6 +12,9 @@ Pod::Spec.new do |s|
     s.pod_target_xcconfig = {
       "SWIFT_VERSION" => "4.2",
     }
+
+    s.swift_version = '4.2'
+
     s.ios.deployment_target = '9.0'
     s.source = { :git => 'https://github.com/MessageKit/MessageInputBar.git', :tag => s.version }
 


### PR DESCRIPTION
Cocoa pod 1.4.0's new convention is to specify the swift_version in the pod spec rather than in .swift_version