### PR TITLE
Use the source image orientation when creating an image text attachment

### DIFF
--- a/Sources/Views/InputTextView.swift
+++ b/Sources/Views/InputTextView.swift
@@ -288,7 +288,7 @@ open class InputTextView: UITextView {
         guard let cgImage = image.cgImage else { return NSTextAttachment() }
         let scale = image.size.width / (frame.width - 2 * (textContainerInset.left + textContainerInset.right))
         let textAttachment = NSTextAttachment()
-        textAttachment.image = UIImage(cgImage: cgImage, scale: scale, orientation: .up)
+        textAttachment.image = UIImage(cgImage: cgImage, scale: scale, orientation: image.imageOrientation)
         return textAttachment
     }
     


### PR DESCRIPTION
Hi Nathan,
  Here is a small PR to correct the image orientation issue identified in https://github.com/MessageKit/MessageInputBar/issues/23

Regards
Nicolas
👻